### PR TITLE
子テーマでbbPress関連PHPテンプレートを設置した場合を想定した調整

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -640,7 +640,7 @@ function override_bbpress_templates_if_inactive( $template ) {
   if ( is_child_theme() ) {
     foreach ( $bbpress_templates as $bbpress_template ) {
       if ( file_exists( get_cocoon_stylesheet_directory() . '/' . $bbpress_template ) ) {
-        return $templates;
+        return $template;
       }
     }
   }

--- a/functions.php
+++ b/functions.php
@@ -599,14 +599,23 @@ function hide_bbpress_templates_if_inactive( $page_templates ) {
   }
 
   // 非アクティブな場合、非表示にしたいbbPressテンプレートのファイル名またはパスを定義
-  $bbpress_templates_to_remove = [
+  $bbpress_templates = [
     'templates/page-create-topic.php',
     'templates/page-front-forums.php',
   ];
 
-  // 現在のテンプレートから、上記で定義したbbPressテンプレートを非表示
-  foreach ( $bbpress_templates_to_remove as $template ) {
-    unset( $page_templates[ $template ] );
+  // 子テーマが有効かつ、子テーマ内にどちらかのテンプレートが存在する場合は何もしない
+  if ( is_child_theme() ) {
+    foreach ( $bbpress_templates as $bbpress_template ) {
+      if ( file_exists( get_cocoon_stylesheet_directory() . '/' . $bbpress_template ) ) {
+        return $page_templates;
+      }
+    }
+  }
+
+  // 非アクティブな場合、非表示にしたいbbPressテンプレートのファイル名またはパスを定義
+  foreach ( $bbpress_templates as $bbpress_template ) {
+    unset( $page_templates[ $bbpress_template ] );
   }
 
   return $page_templates;
@@ -622,13 +631,22 @@ function override_bbpress_templates_if_inactive( $template ) {
 
   // 非アクティブな場合、上書きしたいbbPressテンプレートのファイル名またはパスを定義
   // ここで定義されたテンプレートがもし現在読み込まれている場合、page.phpに切り替えます。
-  $bbpress_templates_to_override = [
+  $bbpress_templates = [
     'templates/page-create-topic.php',
     'templates/page-front-forums.php',
   ];
 
+  // 子テーマが有効かつ、子テーマ内にどちらかのテンプレートが存在する場合は何もしない
+  if ( is_child_theme() ) {
+    foreach ( $bbpress_templates as $bbpress_template ) {
+      if ( file_exists( get_cocoon_stylesheet_directory() . '/' . $bbpress_template ) ) {
+        return $templates;
+      }
+    }
+  }
+
   // 現在のテンプレートが、上書き対象のbbPressテンプレートのいずれかと一致するか確認
-  foreach ( $bbpress_templates_to_override as $bbpress_template ) {
+  foreach ( $bbpress_templates as $bbpress_template ) {
     if ( basename( $template ) === basename( $bbpress_template ) ) {
       // WordPressのテンプレート階層に従い、page.phpを探して返す
       $new_template = locate_template( 'page.php' );


### PR DESCRIPTION
# 本PRの目的

本PRは、先日進めた[こちら](https://github.com/xserver-inc/cocoon/pull/276)の機能に対して、さらにユーザー側で子テーマを作成いただいている場合を想定した調整を追加することを目的としております。

子テーマ内に、親テーマにあるbbPress関連テンプレート「templates\page-create-topic.php」「templates\page-front-forums.php」を設置し、そのPHPテンプレートに対してユーザーが独自にbbPress無効化時の表示処理を実装している場合を想定し、固定ページでの選択制御を解除し選択可能とする調整になります。

つまり、子テーマにてユーザー側で独自にbbPressプラグイン無効化時の分岐処理等を「templates\page-create-topic.php」「templates\page-front-forums.php」へ実装している場合が考えられるため、そのような場合を配慮できればと思います。

子テーマに対してbbPress関連テンプレートを作成していない場合は、これまで通り固定ページでのテンプレートの選択を不可とする調整がされます。

# 関連PR

https://github.com/xserver-inc/cocoon/pull/276

# 修正内容

- 子テーマにてbbPress用のPHPテンプレートファイルが設置されている場合は、bbPress無効化・非インストール時でも固定ページのテンプレートにて「bbPress - Create Topic」「bbPress - Forums(index)」を選択可能とするように修正

今回の修正を簡単にまとめると、以下のイメージです。

```
■ bbPress有効化時
親テーマ→固定ページにてテンプレート選択可能
子テーマ→固定ページにてテンプレート選択可能

■ bbPress無効化時
親テーマ→固定ページにてテンプレート選択不可
子テーマ→固定ページにてテンプレート選択不可（★bbPress関連テンプレートが「設置されている」場合は選択可能）
```

# 前提としている想定パターン

Cocoonの子テーマを利用し、その子テーマに「templates\page-create-topic.php」「templates\page-front-forums.php」を作成し、それぞれのファイルにプラグイン無効化時の処理を独自に実装してページを表示しているケースが考えられます。

この場合の問題点としては、当PRの修正反映前だと「独自実装した表示が勝手にpage.phpに切り替わってしまうことで表示されない」という現象（今回では不具合と認識）が起こってしまうかと思います。

そのため、子テーマに「templates\page-create-topic.php」「templates\page-front-forums.php」があればbbPressをインストール・有効化せずとも固定ページにてテンプレート選択を可能する修正を今回加えさせていただきました。

イメージ的には下図のように独自に分岐処理を追加している場合などがあるかと思います。（例：cocoon-child-master\templates\page-create-topic.phpにコードを追加している場合）

![スクリーンショット 2025-05-30 113543](https://github.com/user-attachments/assets/3e2984bc-da85-4279-8262-67842b729e08)

下図がフロントでの表示イメージです。

<img width="577" alt="スクリーンショット 2025-06-13 104218" src="https://github.com/user-attachments/assets/3bafdf59-9f3c-466d-88ff-092a4ea343e9" />

# 実装イメージ

今回は、先日の[こちらの対応](https://github.com/xserver-inc/cocoon/pull/276)で実装したコードを、以下のコードへ修正いたしました。

そのため、検証いただく場合は以下のコードへ差し替えていただくことで可能です。

```
// bbPressが非アクティブな場合、特定のページテンプレートを非表示にする
add_filter( 'theme_page_templates', 'hide_bbpress_templates_if_inactive' );
function hide_bbpress_templates_if_inactive( $page_templates ) {
  if ( is_bbpress_exist() ) {
    return $page_templates;
  }

  $bbpress_templates = [
    'templates/page-create-topic.php',
    'templates/page-front-forums.php',
  ];

  foreach ( $bbpress_templates as $bbpress_template ) {
    // 子テーマにテンプレートがなければ除外
    if ( !( is_child_theme() && file_exists( get_cocoon_stylesheet_directory() . '/' . $bbpress_template ) ) ) {
      unset( $page_templates[ $bbpress_template ] );
    }
  }

  return $page_templates;
}

// bbPressが非アクティブな場合に、特定のbbPressテンプレートをpage.phpで上書きする
add_filter( 'template_include', 'override_bbpress_templates_if_inactive' );
function override_bbpress_templates_if_inactive( $template ) {
  // bbPressがインストールされている場合は何もしない
  if ( is_bbpress_exist() ) {
    return $template;
  }

  $bbpress_templates = [
    'templates/page-create-topic.php',
    'templates/page-front-forums.php',
  ];

  foreach ( $bbpress_templates as $bbpress_template ) {
    // 現在のテンプレートが対象かつ、子テーマにそのテンプレートが存在しない場合のみpage.phpに切り替え
    if (
      basename( $template ) === basename( $bbpress_template ) &&
      ( !is_child_theme() || !file_exists( get_cocoon_stylesheet_directory() . '/' . $bbpress_template ) )
    ) {
      $new_template = locate_template( 'page.php' );
      if ( !empty( $new_template ) ) {
        return $new_template;
      }
    }
  }

  return $template;
}
```

# 修正後イメージ

■ 子テーマに「page-create-topic.php」「page-front-forums.php」を設置

1. 子テーマを設定します。

![スクリーンショット 2025-05-30 104413](https://github.com/user-attachments/assets/3785217d-03a7-49fd-8ea6-dd4d886b46b3)

2. bbPressは無効化、もしくは非インストール状態にしておきます。

<img width="112" alt="スクリーンショット 2025-05-30 104824" src="https://github.com/user-attachments/assets/aa8b1d23-3c72-43ff-a5d7-3dacb2a64a59" />

3. この時点では、固定ページのテンプレートを確認すると、bbPressテンプレートは選択できなくしております。

<img width="142" alt="スクリーンショット 2025-05-30 105511" src="https://github.com/user-attachments/assets/6c4591f6-9596-4792-8ab1-ced3516b0b7a" />

4. 子テーマ内に親テーマにある「templates\page-create-topic.php」「templates\page-front-forums.php」をそのままコピペしてファイルを追加します。

![スクリーンショット 2025-05-30 104701](https://github.com/user-attachments/assets/736356de-ab31-47fe-8444-ea08e3a69bdb)

そのままコピペしているため、templatesファイルの中身は以下になります。

<img width="152" alt="スクリーンショット 2025-05-30 104749" src="https://github.com/user-attachments/assets/6848694c-092e-49d7-9d03-a21d0743d819" />

5. 設置後、固定ページのテンプレートを確認すると、bbPressテンプレートを選択可能となっております。

<img width="142" alt="スクリーンショット 2025-05-30 105432" src="https://github.com/user-attachments/assets/00b2a2ec-42d8-470f-83b6-143d7cd02e48" />

# 補足

以下の形でbbPress用のテンプレートを作成いただくことでテンプレートの有無を判定できるため、当PRでの機能は適用されます。

- templates\page-create-topic.php
- templates\page-front-forums.php

以下の形で作成した場合は、当PRでの機能は適用されません。

- page-create-topic.php
- page-front-forums.php