### PR TITLE
「本文全ての目次を表示する」をONにした時に「表示条件」が効かなくなる挙動を調整

### DIFF
--- a/lib/toc.php
+++ b/lib/toc.php
@@ -251,10 +251,9 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
   </div>';
 
   global $_TOC_AVAILABLE_H_COUNT;
-  // 本文全ての目次を表示する場合は全ページの見出し数、そうでない場合は現在ページの見出し数
-  $available_h_count = $is_multi_page_toc_visible ? $header_count : $counter;
-  $_TOC_AVAILABLE_H_COUNT = $available_h_count;
-  if (!is_toc_display_count_available($available_h_count)){
+  // 表示条件は本文中の全見出し数で判定（深さ制限で除外される見出しも含む）
+  $_TOC_AVAILABLE_H_COUNT = $header_count;
+  if (!is_toc_display_count_available($header_count)){
     return ;
   }
 

--- a/lib/toc.php
+++ b/lib/toc.php
@@ -251,8 +251,10 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
   </div>';
 
   global $_TOC_AVAILABLE_H_COUNT;
-  $_TOC_AVAILABLE_H_COUNT = $counter;
-  if (!is_toc_display_count_available($counter)){
+  // 本文全ての目次を表示する場合は全ページの見出し数、そうでない場合は現在ページの見出し数
+  $available_h_count = $is_multi_page_toc_visible ? $header_count : $counter;
+  $_TOC_AVAILABLE_H_COUNT = $available_h_count;
+  if (!is_toc_display_count_available($available_h_count)){
     return ;
   }
 


### PR DESCRIPTION
# 本PRの目的

「本文全ての目次を表示する」をONにした時に「表示条件」との挙動で不具合がみられたため、調整できればと思います。

確認できた挙動としては、「本文全ての目次を表示する」をONにした場合、「表示条件」に関係なく常時目次が表示されてしまう不具合になります。

例えば、本文中に見出しが3つあるとして、「表示条件」で「5つ以上見出しがあるとき」を設定した場合に、通常5つ以上とう条件を持たさないため、目次は非表示になるかと思いますが、表示されてしまう形になります。

# 対応状況

- [x] 実装
- [ ] 動作テスト

# 対応内容

- lib\toc.phpのget_toc_tag()関数

# 不具合再現方法

以下のコードをエディタにコピペします。（見出し3つ、段落3つのセットになります）

```
<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading">これはテストです</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>これはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストですこれはテストです</p>
<!-- /wp:paragraph -->
```

コピペしていただくと、下図のように表示されます。

<img width="677" height="424" alt="スクリーンショット 2025-12-03 113717" src="https://github.com/user-attachments/assets/606711a8-bd9b-4330-b169-e99e75603057" />

下図のように「本文全ての目次を表示する」をONにしていただき、「表示条件」を「5」とします。

![スクリーンショット 2025-12-02 144710](https://github.com/user-attachments/assets/4f99a96e-40e0-4823-a52a-a38a5a72a815)

再度フロントをご確認いただくと、下図のように目次が表示されてしまう現象が確認できるかと思います。

<img width="419" height="204" alt="スクリーンショット 2025-12-17 125534" src="https://github.com/user-attachments/assets/83448661-c663-4512-bbb4-fac6ffc8c90d" />

# 原因

不具合の根本原因は、表示条件の判定に使用していた$counter変数が、分割ページモードにおいて最後のページの見出し数しか保持していなかったことにあるかと思います。

■ 問題のあったコード（修正前）

lib\toc.php 254行目付近

```
$_TOC_AVAILABLE_H_COUNT = $counter;
if (!is_toc_display_count_available($counter)){
  return ;
}
```

$counter変数はページ遷移時にリセットされる仕様のため、最後のページの見出し数しか保持できません。

そのため、表示条件の判定には、リセットの影響を受けない$header_countを使用することで、技術的に正確な判定が可能になります。

$header_countはcount($headers)で算出されるため、常に正確な見出し総数を保持します。

分割ページモードでは、全ページから抽出された見出しが$headers配列に格納され、その要素数をカウントすることで確実に全ページの見出し総数を取得できます。

# 対策

表示条件の判定に$header_count（本文中の全見出し数）を使用するよう修正しました。

■ 修正後のコード

lib\toc.php 254行目付近

```
global $_TOC_AVAILABLE_H_COUNT;
// 表示条件は本文中の全見出し数で判定（深さ制限で除外される見出しも含む）
$_TOC_AVAILABLE_H_COUNT = $header_count;
if (!is_toc_display_count_available($header_count)){
  return ;
}
```

## $header_countを利用した理由

$header_countは常に正確な見出し総数を保持するのと、$header_countを利用することでメモリの最適化、コードがすっきりし保守性も上がるため、こちらで調整いたしました。

get_toc_tag関数にて、分割ページモードでは、配列の要素数（全ページの見出し総数）を取得し、通常モードでは、正規表現でマッチした全見出し数を取得する処理となっていることと思います。

処理としては、問題の原因となった$counter変数はページ遷移時にリセットされる仕様のため、最後のページの見出し数しか保持できません。表示条件の判定には、リセットの影響を受けない$header_countを使用することで、技術的に正確な判定が可能になります。

# 動作確認

## 基本テスト

- [ ] 通常ページの目次表示（分割なし）
- [ ] 分割ページの目次表示（「本文全ての目次を表示する」ON）
- [ ] 表示条件「3つ以上」で2個の記事 → 非表示
- [ ] 表示条件「3つ以上」で3個の記事 → 表示
- [ ] 表示条件「5つ以上」で分割ページ（3個+2個） → 表示

## ウィジェット・ショートコードテスト

- [ ] サイドバーの目次ウィジェット
- [ ] 本文中の[toc]ショートコード
- [ ] 本文中ウィジェットエリアの目次ウィジェット

## 設定組み合わせテスト

- [ ] 深さ制限「H3まで」+ H2×2 + H4×3 → 表示（5個でカウント）
- [ ] 「本文全ての目次を表示する」OFF → 従来通り動作

## その他

他Cocoon設定等で影響範囲に問題ないか

# 調査メモ

$counter（目次に表示される見出し数）
$header_count（本文中の全見出し数）