### PR TITLE
【ご確認のみ】【※認識がずれている可能性があるため保留】ショートコードで指定したtarget属性がCocoon設定で上書きされる問題を修正 

### DIFF
--- a/lib/links.php
+++ b/lib/links.php
@@ -223,6 +223,10 @@ if ( !function_exists( 'replace_target_attr_tag' ) ):
 function replace_target_attr_tag( $link_open_type, $the_a_tag ) {
   //リンクの開き方を変更する場合
   if ($link_open_type != 'default') {
+    //既にtarget属性が設定されている場合は、それを尊重する
+    if (preg_match('/ *target="[^"]*?"/i', $the_a_tag)) {
+      return $the_a_tag;
+    }
     //外部リンクの開き方を変更する場合はtarget属性のクリアを行う
     $the_a_tag = preg_replace('/ *target="[^"]*?"/i', '', $the_a_tag);
     switch ($link_open_type) {

--- a/tests/Unit/LinksTest.php
+++ b/tests/Unit/LinksTest.php
@@ -182,12 +182,13 @@ class LinksTest extends TestCase
         $this->assertStringContainsString('target="_self"', $result);
     }
 
-    public function test_replace_target_attr_tag_blankで既存のtargetを置換する(): void
+    public function test_replace_target_attr_tag_既存のtargetは尊重される(): void
     {
         $tag = '<a href="https://example.com" target="_self">リンク</a>';
         $result = replace_target_attr_tag('blank', $tag);
-        $this->assertStringContainsString('target="_blank"', $result);
-        $this->assertStringNotContainsString('target="_self"', $result);
+        // 既存のtarget属性が設定されている場合は、それを尊重する
+        $this->assertStringContainsString('target="_self"', $result);
+        $this->assertStringNotContainsString('target="_blank"', $result);
     }
 
     public function test_replace_target_attr_tag_defaultでは変更しない(): void


### PR DESCRIPTION
わいひらさん
お世話になっております。

お待たせしており申し訳ありません。
お手数ですが、お手すきで以下ご確認いただけましたら幸いです。

もしそもそものところで何かご認識等ずれがありましたら、お気軽にご指摘いただけましたら幸いです！

# 本PRについて

ややこしく申し訳ございません。
Cocoonをフォークした高澤のリポジトリにて調整を加えたPRとなっておりますが、諸々見直したところ、そもそも現行の仕様は正しく調整の必要はないためコードを調整したい意図は無く、以下内容のみご確認いただければと思い本PRを作成いたしました。
本PRの調整コードに関しては、スルーしていただけますと幸いです🙇

# ご確認内容

[Cocoon公式サイト](https://wp-cocoon.com/)にて、Cocoon設定「本文」→「外部リンク設定」→「外部リンクの開き方」に関して「新しいタブで開く（_blank）」となっているかどうか、をご確認できればと思います。

![スクリーンショット 2026-03-04 185648](https://github.com/user-attachments/assets/f7c62db4-945a-45a7-9f4f-858ca85e82f3)

申し訳ありません、こちらCocoon設定に関して高澤の方でユーザー権限がなく、社内でも確認が取れなかったため、わいひらさんへご確認させていただく運びとなりました。

# ご確認の背景（問題とする挙動）

以下フォーラムにてご指摘いただいた内容の通り、「RSS記事一覧を表示するショートコードの利用方法」ページの[「 taget」の説明セクション](https://wp-cocoon.com/rss-shortcode/#toc9)にて、RSSショートコード出力のカードが別タブでページが開いてしまう挙動がみられました。

![スクリーンショット 2026-03-10 212058](https://github.com/user-attachments/assets/9aa1c2cb-4510-4f3a-b7f3-d4e79e758c2a)

フォーラム：
[RSSショートコードのsiteオプションの表示例ミス](https://wp-cocoon.com/community/typos/rss%e3%82%b7%e3%83%a7%e3%83%bc%e3%83%88%e3%82%b3%e3%83%bc%e3%83%89%e3%81%aesite%e3%82%aa%e3%83%97%e3%82%b7%e3%83%a7%e3%83%b3%e3%81%ae%e8%a1%a8%e7%a4%ba%e4%be%8b%e3%83%9f%e3%82%b9/)

この場合RSSショートコードのにtargetオプションとして「_self」を追加すればよいですが、エディタ上ではtargetオプションを「_self」としているのに、別タブで開いてしまうという挙動となっていることと思います。

![スクリーンショット 2026-03-10 210126](https://github.com/user-attachments/assets/6d9c002f-d4e1-4510-93c9-d6cf7e55e6e7)

# 解決策

Cocoon設定「本文」→「外部リンク設定」→「外部リンクの開き方」を「変更しない」に設定いただくと、上記問題とする挙動を解決できるかと思いました。

→ただ、こちらの変更によりマニュアルページにて影響範囲には注意が必要かと思いました。

以下影響範囲をおまとめいたしました。

```
「変更しない」に設定した場合の挙動。

[box_menu]
→外部リンクは同じタブで開く形に変わります（メニュー機能で「リンクを新しいタブで開く」をOFFにしている場合）
[rss]
→別タブで開くままとなります（targetオプションで「_self」を指定していない、もしくは無指定のデフォルトの場合）
[navi] / [navi_list]
→同じタブで開く形に変わります
[rank]
→「詳細ページ」ボタンが同じタブで開く形に変わります
[template]
→同じタブで開きます
[new_list] / [popular_list]
→特に影響なし
[info_list]
→特に影響なし
```

上記想定になりますが、もし影響がでて修正が必要なページ等でてきましたら、私のほうで調整対応させていただきます。

# 仕様の認識

target属性の優先順位について以下のように上から優先されて処理される認識です。

【①：最優先】
Cocoon設定「本文」→「外部リンク設定」→「外部リンクの開き方」

【②：①の次に優先】
RSSショートコードのtargetオプション指定

【③：②の次に優先】
RSSショートコードのデフォルト設定（target="_blank"）


本件、お手数おかけいたしますが、お手すきでご確認のほど、よろしくお願いいたします。